### PR TITLE
Move Opus tests to same dir as Mumble's tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,8 @@ if(BUILD_TESTING)
 
   # tests
   add_executable(test_opus_decode ${test_opus_decode_sources})
+  # For the Mumble project we'll want all tests to live in build/tests
+  set_target_properties(test_opus_decode PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
   target_include_directories(test_opus_decode
                              PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
   target_link_libraries(test_opus_decode PRIVATE opus)
@@ -317,6 +319,8 @@ if(BUILD_TESTING)
   add_test(test_opus_decode test_opus_decode)
 
   add_executable(test_opus_padding ${test_opus_padding_sources})
+  # For the Mumble project we'll want all tests to live in build/tests
+  set_target_properties(test_opus_padding PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
   target_include_directories(test_opus_padding
                              PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
   target_link_libraries(test_opus_padding PRIVATE opus)


### PR DESCRIPTION
This also has the nice side-effect of fixing the error code 0xc0000135 for these tests on windows where they couldn't find the opus.dll

I don't know whether this might break compatibility with the old buildsystem though (for the 1.3.x series) but I guess if it does, we simply don't update the submodule and be done with it :shrug: 